### PR TITLE
Fix TOML syntax

### DIFF
--- a/oxocarbon-dark.toml
+++ b/oxocarbon-dark.toml
@@ -5,7 +5,7 @@ foreground = "#ffffff"
 
 # Search colors
 [colors.search.matches]
-foreground = CellBackground
+foreground = 'CellBackground'
 background = '#ee5396'
 
 # Normal colors

--- a/templates/oxocarbon-dark.toml.j2
+++ b/templates/oxocarbon-dark.toml.j2
@@ -5,7 +5,7 @@ foreground = "#{{ base06 }}"
 
 # Search colors
 [colors.search.matches]
-foreground = CellBackground
+foreground = 'CellBackground'
 background = '#{{ base0A }}'
 
 # Normal colors


### PR DESCRIPTION
When using current TOML file, I faced with this error

<img width="1756" height="187" alt="image" src="https://github.com/user-attachments/assets/4c4c82ea-3531-4eae-a308-900960b11d98" />

In TOML, string value(s) must be quoted. This PR should fix that error.